### PR TITLE
add small example database

### DIFF
--- a/lib/DockingCompute.pm
+++ b/lib/DockingCompute.pm
@@ -79,6 +79,10 @@ sub run
         {
         $ligand_file = $self->load_ligand_library("/vol/bvbrc/production/application-backend/bvbrc_docking/test.txt");
         }
+        elsif ($params->{ligand_named_library} eq 'small_db')
+        {
+        $ligand_file = $self->load_ligand_library("/vol/bvbrc/production/application-backend/bvbrc_docking/small_db.txt");
+        }
         else
         {
         die "Unknown ligand library type selected $params->{ligand_library_type}";


### PR DESCRIPTION
Hello,
This is a single commit to add a small ligand database option that runs quickly. This should run in around 10 minutes. I have tested this database with multiple proteins. It will also trigger two errors, RDKit's error and the DiffDock incompatible ligand error.
These changes have been tested and are ready to be tested on alpha.

Kind regards,
Nicole 